### PR TITLE
Add PR comment if the action contributing guidelines have been met

### DIFF
--- a/.github/workflows/reusable-build-and-review-pr.yml
+++ b/.github/workflows/reusable-build-and-review-pr.yml
@@ -246,3 +246,46 @@ jobs:
               .addRaw(instructionsWithLinks)
               .write();
             core.setFailed(instructions);
+      
+      # ----------------------------------------------------
+      # Add comment if Contributing Guidelines are satisfied
+      # ----------------------------------------------------
+      - name: Add comment if contributing guidelines are satisfied
+        if: env.HAS_CODE_CHANGES == 'true' &&  env.NEEDS_BUILD_COMMIT == 'false' && env.NEEDS_README_COMMIT == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+
+            // Setup vars for the script to use
+            const hasBuildStep =  ${{ env.HAS_BUILD_STEP }};
+            
+            const contribId = '${{ inputs.readme-contribution-id }}';
+            const contributionLink = `https://github.com/${{ github.repository }}${contribId}`;
+            const contributingTitle = contribId.replace('#', '').split('-').map(w => { return w.slice(0, 1).toUpperCase() + w.slice(1) }).join(' ');
+
+            const exampleId = '${{ inputs.readme-examples-id }}';
+            const readmeLink = `${{ github.event.pull_request.head.repo.html_url }}/blob/${{ github.event.pull_request.head.ref }}/${{ env.README }}`;
+            const readmeExampleLink = `${readmeLink}${exampleId}`;
+            const readmeExampleTitle = exampleId.replace('#', '').split('-').map(w => { return w.slice(0, 1).toUpperCase() + w.slice(1) }).join(' ');
+
+            // Construct the prComment
+            let prComment = `The action's [${contributingTitle} Guidelines](${contributionLink}) have been met:
+            - The action's version in the [${readmeExampleTitle}](${readmeExampleLink}) section of [${{ env.README }}](${readmeLink}) has been updated to \`@${{ env.NEXT_VERSION }}\``
+            
+            if (hasBuildStep){
+              prComment += `
+            - The action has been recompiled (if needed) by running the build command from the root of the repository`;
+            }
+
+            // Comment on PR for branches.  A fork's GH_TOKEN only has 'read' permission on all scopes so a comment cannot be made.
+            if (!${{ env.IS_FORK }}) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: prComment
+              })
+            }
+
+            // Add workflow summary
+            core.summary.addRaw(prComment).write();


### PR DESCRIPTION
# Summary of PR changes

This adds a PR comment if there are changes to the action and the contributing guidelines have been met.  This includes recompiling the action and updating the version in the readme.  Previously you only got a comment on the PR and the workflow summary if you needed to make changes.  Once those changes were addressed there wasn't an indication that you addressed the issue other than the status check being updated but it was a little confusing with the outstanding comment.

This was tested in an action that has a build step and one that does not:
- No build step: https://github.com/im-open/octostache-action/pull/21
- Build step: https://github.com/im-open/open-pagerduty-maintenance-window/pull/25

