### PR TITLE
Upload a copy of the dist/ dir

### DIFF
--- a/.github/workflows/reusable-build-and-review-pr.yml
+++ b/.github/workflows/reusable-build-and-review-pr.yml
@@ -247,6 +247,16 @@ jobs:
               .write();
             core.setFailed(instructions);
       
+      # Sometimes a user's local build doesn't match the runner environment no matter what settings are changed.
+      #  Upload a copy of dist/ in that case so the user can update their branch with a runner compiled version.
+      - name: Upload a copy of dist/index.js if the action needs to be recompiled
+        if: env.HAS_CODE_CHANGES == 'true' &&  env.NEEDS_BUILD_COMMIT == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
       # ----------------------------------------------------
       # Add comment if Contributing Guidelines are satisfied
       # ----------------------------------------------------


### PR DESCRIPTION
# Summary of PR changes

- This is to help users when they can't get their local build to match what the github runner expects.  In most cases it is easier to run the build locally then commit, but in some cases you might have to download this, review the changes and commit it to your branch so the build runner is satisfied with the recompiled action.